### PR TITLE
Removing files section from nuspec so we generate a full release

### DIFF
--- a/Dist/FHSDK.nuspec
+++ b/Dist/FHSDK.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>FH.SDK</id>
-    <version>1.3.7.1</version>
+    <version>1.3.7.2</version>
     <authors>FeedHenry</authors>
     <owners>FeedHenry</owners>
     <projectUrl>https://github.com/feedhenry/fh-dotnet-sdk</projectUrl>
@@ -51,7 +51,8 @@
 
        <group targetFramework="monoandroid">
         <dependency id="Newtonsoft.Json" version="8.0.3" />
-        <dependency id="Unity" version="4.0.1" />
+        <dependency id="Xamarin.Android.Support.v4" version="23.1.1" />
+        <dependency id="Xamarin.GooglePlayServices.Gcm" version="29.0.0.2" />        
        </group>
 
        <group targetFramework="monotouch">
@@ -61,13 +62,4 @@
 
     </dependencies>
   </metadata>
-  <files>
-    <file src="lib/monoandroid/*.dll" target="lib/monoandroid" />
-    <file src="lib/portable-net45+wp80+wp81+win8+wpa81/*.dll" target="lib/portable-net45+wp80+wp81+win8+wpa81" />
-    <file src="lib/portable-win81+wpa81/*.dll" target="lib/portable-win81+wpa81" />
-    <file src="lib/wp80/*.dll" target="lib/wp80" />
-    <file src="lib/wpa81/*.dll" target="lib/wpa81" />
-    <file src="lib/xamarinios10/*.dll" target="lib/xamarinios10"/>
-    <file src="**/*.cs" target="src"/>
-  </files>
 </package>


### PR DESCRIPTION
I removed the files section from nuspec.  This was causing the library to generate an empty package and this meant nothing was getting deployed.