### PR TITLE
Point to the last version of AeroGear.

### DIFF
--- a/Dist/FHSDK.nuspec
+++ b/Dist/FHSDK.nuspec
@@ -16,7 +16,7 @@
         <dependency id="Newtonsoft.Json" version="8.0.3" />
         <dependency id="Microsoft.Net.Http" version="2.2.29" />
         <dependency id="Unity" version="4.0.1" />
-        <dependency id="aerogear-windows-push" version="(0.1,]" />
+        <dependency id="aerogear-windows-push" version="0.1.2" />
         <dependency id="Microsoft.Bcl.Build" version="(1.0,]" />
       </group>
 
@@ -25,13 +25,13 @@
         <dependency id="Xamarin.GooglePlayServices.Gcm" version="29.0.0.2" />
         <dependency id="Newtonsoft.Json" version="8.0.3" />
         <dependency id="Unity" version="4.0.1" />
-        <dependency id="aerogear-windows-push" version="(0.1,]" />
+        <dependency id="aerogear-windows-push" version="0.1.2" />
        </group>
 
        <group targetFramework="xamarinios10">
         <dependency id="Newtonsoft.Json" version="8.0.3" />
         <dependency id="Unity" version="4.0.1" />
-        <dependency id="aerogear-windows-push" version="(0.1,]" />
+        <dependency id="aerogear-windows-push" version="0.1.2" />
        </group>
 
     </dependencies>


### PR DESCRIPTION
Hi, 

Currently if we trying to install latest FH.SDK from nuget on the latest Xamarin.iOS version (11.+) we will got installing error.
<img width="1280" alt="screen shot 2018-03-01 at 23 54 40" src="https://user-images.githubusercontent.com/10769847/37086197-0700379e-2208-11e8-98e4-63f308773e61.png">

It's because **NuGet by default resolve the lowest major.minor version** within the range allowed. (_AeroGear 0.1.1_ in our case).

With _AeroGear 0.1.2_  FH.SDK installed correctly as expected.

Thanks.
