### PR TITLE
Enabled URL modifier for implementing reverse-proxy

### DIFF
--- a/FHSDK/Config/CloudProps.cs
+++ b/FHSDK/Config/CloudProps.cs
@@ -13,6 +13,11 @@ namespace FHSDK
         private string _hostUrl;
         private readonly FHConfig _config;
 
+        // Optional modifier to help with doing reverse-proxy
+        public delegate string HostUrlModifier(string srcUrl);
+        // The default Host URL modifier is null. Clients may set it if required.
+        public static HostUrlModifier UrlModifier;
+
         /// <summary>
         ///     Constructor
         /// </summary>
@@ -64,6 +69,8 @@ namespace FHSDK
                 }
             }
             _hostUrl = _hostUrl.EndsWith("/") ? _hostUrl.Substring(0, _hostUrl.Length - 1) : _hostUrl;
+            if (UrlModifier != null)
+                _hostUrl = UrlModifier(_hostUrl);
             return _hostUrl;
         }
 
@@ -79,3 +86,4 @@ namespace FHSDK
         }
     }
 }
+

--- a/FHSDK/FH.cs
+++ b/FHSDK/FH.cs
@@ -41,6 +41,16 @@ namespace FHSDK
         }
 
         /// <summary>
+        /// Gets the host env. Mainly introduced to support clients
+        /// when transforming URLs where environment name plays a key part.
+        /// </summary>
+        /// <returns>The host env, e.g. dev</returns>
+        public static string GetHostEnv()
+        {
+            return CloudProps.GetEnv();
+        }
+
+        /// <summary>
         ///     Get or Set the timeout value for all the requests. Default is 30 seconds.
         /// </summary>
         public static TimeSpan TimeOut


### PR DESCRIPTION
Customers with mobile clients that need to reverse-proxy to overcome firewall issues require a way of customising the host URL. This change provides them with a hook they can use to perform such a transformation.
Clients requiring reverse-proxy functionality first need to implement a method to perform the URL transformation. Example:
`public static string MakeProxyUrl(string orgUrl) { ... }`
**Before** calling `FHClient.Init()` the client must set the URL modifier delegate in the SDK:
`CloudProps.UrlModifier = MakeProxyUrl;`

Customers who don't need to reverse-proxy need not make any changes to their mobile clients and remain unaffected by this change.
